### PR TITLE
Don't use a Ruby alpine for audiowaveform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM alpine as audiowaveform-builder
 
 RUN apk add --no-cache boost-dev boost-static cmake curl g++ gcc gd-dev git \
-    jq libid3tag-dev libmad-dev libpng-static libsndfile-dev libvorbis-static make zlib-static libsndfile1
+    jq libid3tag-dev libmad-dev libpng-static libsndfile libsndfile-dev libvorbis-static make zlib-static
 
 RUN apk add --no-cache autoconf automake libtool gettext && \
     curl -fL# "$(curl -s 'https://api.github.com/repos/xiph/flac/tags' | jq -r '. | first | .tarball_url')" -o flac.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # from https://github.com/realies/audiowaveform-docker/blob/master/Dockerfile
 
-FROM alpine as audiowaveform-builder
+FROM ruby:3.0.5-alpine as audiowaveform-builder
 
 RUN apk add --no-cache boost-dev boost-static cmake curl g++ gcc gd-dev git \
     jq libid3tag-dev libmad-dev libpng-static libsndfile-dev libvorbis-static make zlib-static

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # from https://github.com/realies/audiowaveform-docker/blob/master/Dockerfile
 
-FROM ruby:3.0.5-alpine as audiowaveform-builder
+FROM alpine as audiowaveform-builder
 
 RUN apk add --no-cache boost-dev boost-static cmake curl g++ gcc gd-dev git \
-    jq libid3tag-dev libmad-dev libpng-static libsndfile-dev libvorbis-static make zlib-static
+    jq libid3tag-dev libmad-dev libpng-static libsndfile-dev libvorbis-static make zlib-static libsndfile1
 
 RUN apk add --no-cache autoconf automake libtool gettext && \
     curl -fL# "$(curl -s 'https://api.github.com/repos/xiph/flac/tags' | jq -r '. | first | .tarball_url')" -o flac.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # from https://github.com/realies/audiowaveform-docker/blob/master/Dockerfile
 
-FROM ruby:2.7.5-alpine as audiowaveform-builder
+FROM alpine as audiowaveform-builder
 
 RUN apk add --no-cache boost-dev boost-static cmake curl g++ gcc gd-dev git \
     jq libid3tag-dev libmad-dev libpng-static libsndfile-dev libvorbis-static make zlib-static


### PR DESCRIPTION
If we do this, the image is only usable in the exact same `ruby:2.7.5-alpine` container. 